### PR TITLE
add/journey android 5.5.1

### DIFF
--- a/docs/journey/android/changelogs.md
+++ b/docs/journey/android/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Available versions
 
+* [v5.5.1](releases/5.5.1/index.md) (_27 Apr 2023_)
 * [v5.5.0](releases/5.5.0/index.md) (_03 Apr 2023_)
 * [v5.4.1](releases/5.4.1/index.md) (_22 Mar 2023_)
 * [v5.4.0](releases/5.4.0/index.md) (_17 Mar 2023_)

--- a/docs/journey/android/index.md
+++ b/docs/journey/android/index.md
@@ -6,7 +6,7 @@ Add the following dependencies in the `build.gradle` file of your application:
 
 ``` groovy
 dependencies {
-    implementation("com.kisio.navitia.sdk.ui:journey:5.3.0")
+    implementation("com.kisio.navitia.sdk.ui:journey:5.5.1")
 }
 ```
 

--- a/docs/journey/android/releases/5.5.1/index.md
+++ b/docs/journey/android/releases/5.5.1/index.md
@@ -1,0 +1,6 @@
+# Journey Android 5.5.1 Changelog
+
+<h2>🗓 27 Apr 2023</h2>
+
+#### Fixes
+- Fix home and work buttons are showing when bookmark mode is disabled


### PR DESCRIPTION
- add journey android and traffic android releases
- add around me android, bookmark android and schedule android releases
- Add changelogs for ios releases
- Add alert subscription feature
- Add missing screens
- Update index.md
- Add Traffic version 3.3.1 for iOS
- Add journey android 5.5.1
