### PR TITLE
task/add journey hotfix 5.y.x

### DIFF
--- a/docs/journey/android/changelogs.md
+++ b/docs/journey/android/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Available versions
 
+* [v5.6.0](releases/5.6.0/index.md) (_30 May 2023_)
 * [v5.5.2](releases/5.5.2/index.md) (_11 May 2023_)
 * [v5.5.1](releases/5.5.1/index.md) (_27 Apr 2023_)
 * [v5.5.0](releases/5.5.0/index.md) (_03 Apr 2023_)

--- a/docs/journey/android/index.md
+++ b/docs/journey/android/index.md
@@ -6,7 +6,7 @@ Add the following dependencies in the `build.gradle` file of your application:
 
 ``` groovy
 dependencies {
-    implementation("com.kisio.navitia.sdk.ui:journey:5.5.1")
+    implementation("com.kisio.navitia.sdk.ui:journey:5.6.0")
 }
 ```
 

--- a/docs/journey/android/releases/5.6.0/index.md
+++ b/docs/journey/android/releases/5.6.0/index.md
@@ -2,11 +2,8 @@
 
 <h2>🗓 30 May 2023</h2>
 
-#### Feature
+#### Task
 - Hide times in ridesharing offers and roadmap
-
-#### Tasks
-- Upgrade minSdk to API level 23
 
 #### Fixes
 - Fix disruption formatting in roadmap

--- a/docs/journey/android/releases/5.6.0/index.md
+++ b/docs/journey/android/releases/5.6.0/index.md
@@ -1,0 +1,12 @@
+# Journey Android 5.6.0 Changelog
+
+<h2>🗓 30 May 2023</h2>
+
+#### Feature
+- Hide times in ridesharing offers and roadmap
+
+#### Tasks
+- Upgrade minSdk to API level 23
+
+#### Fixes
+- Fix disruption formatting in roadmap

--- a/docs/journey/ios/changelogs.md
+++ b/docs/journey/ios/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Available versions
 
+* [v5.4.6](releases/5.4.6/index.md) (_30 May 2023_)
 * [v5.4.5](releases/5.4.5/index.md) (_11 May 2023_)
 * [v5.4.4](releases/5.4.4/index.md) (_03 Apr 2023_)
 * [v5.4.3](releases/5.4.3/index.md) (_24 Mar 2023_)

--- a/docs/journey/ios/index.md
+++ b/docs/journey/ios/index.md
@@ -12,7 +12,7 @@ source 'https://github.com/CocoaPods/Specs.git' # Default Cocoapods URL
 source 'https://github.com/hove-io/Podspecs.git' # Journey podspec URL
 
 target 'YOUR_PROJECT_SCHEME' do
-  pod 'JourneySDK', '5.3.2' # Journey Pod definition
+  pod 'JourneySDK', '5.4.6' # Journey Pod definition
 end
 
 # Required for XCFramework

--- a/docs/journey/ios/releases/5.4.6/index.md
+++ b/docs/journey/ios/releases/5.4.6/index.md
@@ -1,0 +1,11 @@
+# Journey iOS 5.4.6 Changelog
+
+<h2>🗓 30 May 2023</h2>
+
+#### Tasks
+- Hide journey time for ridesharing offers
+
+#### Fixes
+- Fix font for disruption messages
+- Fix rating stars display
+- Show free instead of 0€ for ridesharing offers


### PR DESCRIPTION
- add journey android and traffic android releases
- add around me android, bookmark android and schedule android releases
- Add changelogs for ios releases
- Add alert subscription feature
- Add missing screens
- Update index.md
- Add Traffic version 3.3.1 for iOS
- Add journey android 5.5.1
- Add journey android 5.5.2, journey ios 5.4.5
- Add journey ios 5.4.6, android 5.6.0
