### PR TITLE
task/add journey hotfix 5.y.x 2

### DIFF
--- a/docs/bookmark/ios/releases/1.2.2/index.md
+++ b/docs/bookmark/ios/releases/1.2.2/index.md
@@ -1,0 +1,7 @@
+# Bookmark iOS 1.2.2 Changelog
+
+<h2>🗓 18 Jul 2023</h2>
+
+#### Fixes
+- Fix Realm configuration objects
+- Fix Go from/go to not redirecting to Journey module

--- a/docs/bookmark/ios/releases/1.2.2/index.md
+++ b/docs/bookmark/ios/releases/1.2.2/index.md
@@ -2,6 +2,5 @@
 
 <h2>🗓 18 Jul 2023</h2>
 
-#### Fixes
-- Fix Realm configuration objects
-- Fix Go from/go to not redirecting to Journey module
+#### Tasks
+- Update dependencies

--- a/docs/journey/android/changelogs.md
+++ b/docs/journey/android/changelogs.md
@@ -2,6 +2,8 @@
 
 ## Available versions
 
+* [v5.6.2](releases/5.6.2/index.md) (_18 Jul 2023_)
+* [v5.6.1](releases/5.6.1/index.md) (_30 May 2023_)
 * [v5.6.0](releases/5.6.0/index.md) (_30 May 2023_)
 * [v5.5.2](releases/5.5.2/index.md) (_11 May 2023_)
 * [v5.5.1](releases/5.5.1/index.md) (_27 Apr 2023_)

--- a/docs/journey/android/index.md
+++ b/docs/journey/android/index.md
@@ -6,7 +6,7 @@ Add the following dependencies in the `build.gradle` file of your application:
 
 ``` groovy
 dependencies {
-    implementation("com.kisio.navitia.sdk.ui:journey:5.6.0")
+    implementation("com.kisio.navitia.sdk.ui:journey:5.6.2")
 }
 ```
 

--- a/docs/journey/android/releases/5.6.1/index.md
+++ b/docs/journey/android/releases/5.6.1/index.md
@@ -1,0 +1,7 @@
+# Journey Android 5.6.1 Changelog
+
+<h2>🗓 30 May 2023</h2>
+
+#### Dependencies
+- `com.kisio.navitia.sdk.ui:bookmark` > `1.2.3`
+- `com.kisio.navitia.sdk.engine:design` > `2.8.1`

--- a/docs/journey/android/releases/5.6.2/index.md
+++ b/docs/journey/android/releases/5.6.2/index.md
@@ -1,0 +1,10 @@
+# Journey Android 5.6.2 Changelog
+
+<h2>🗓 18 Jul 2023</h2>
+
+#### Features
+- Show number of offers in journey solutions
+- Add display of ridesharing price in configuration
+
+#### Fixes
+- Re-show ridesharing time on a offer

--- a/docs/journey/ios/changelogs.md
+++ b/docs/journey/ios/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Available versions
 
+* [v5.4.7](releases/5.4.7/index.md) (_18 Jul 2023_)
 * [v5.4.6](releases/5.4.6/index.md) (_30 May 2023_)
 * [v5.4.5](releases/5.4.5/index.md) (_11 May 2023_)
 * [v5.4.4](releases/5.4.4/index.md) (_03 Apr 2023_)

--- a/docs/journey/ios/index.md
+++ b/docs/journey/ios/index.md
@@ -12,7 +12,7 @@ source 'https://github.com/CocoaPods/Specs.git' # Default Cocoapods URL
 source 'https://github.com/hove-io/Podspecs.git' # Journey podspec URL
 
 target 'YOUR_PROJECT_SCHEME' do
-  pod 'JourneySDK', '5.4.6' # Journey Pod definition
+  pod 'JourneySDK', '5.4.7' # Journey Pod definition
 end
 
 # Required for XCFramework

--- a/docs/journey/ios/index.md
+++ b/docs/journey/ios/index.md
@@ -60,13 +60,15 @@ do {
                                                  iconRes: "ic_section_mode_metro",
                                                  nameRes: "metro",
                                                  selected: true,
-                                                 modes: [TransportCategoryMode(physical: TransportPhysicalMode(id: "physical_mode:Metro", nameRes: "metro"),
-                                                 commercial: TransportCommercialMode(id: "commercial_mode:Metro", name: "Metro"))],
+                                                 modes: [TransportCategoryMode(physical: TransportPhysicalMode(id "physical_mode:Metro"),
+                                                                               commercial: TransportCommercialMode(id: "commercial_mode:Metro", name: "Metro"))],
+                                                 networks: [],
                                                  firstSectionModes: ["walking"],
-                                                 lastSectionModes: ["walking"])
-                              ]
-                              
-    let journeyColorsConfiguration = JourneyColorsConfiguration(primaryColor: "#88819f", secondaryColor: "#8faa96")
+                                                 lastSectionModes: ["walking"],
+                                                 directPathModes: ["walking"],
+                                                 addPoiInfos: [])]
+            
+    let journeyColorsConfiguration = JourneyColorsConfiguration(primary: "#88819f", secondary: "#8faa96")
                                                                       
     try JourneySdk.shared.initialize(coverage: "fr-idf",
                                     token: "your_token",
@@ -101,13 +103,9 @@ JourneySdk.shared.tracker = self
 This module has a single entry point. 
 
 ```swift
-guard let journeyViewController = JourneySdk.shared.rootViewController else {
-  return nil
+if let journeyViewController = JourneySdk.shared.rootViewController {
+  navigationController?.pushViewController(journeyViewController, animated: false)
 }
-
-journeyViewController.journeysRequest = JourneysRequest()
-
-navigationController?.pushViewController(journeyViewController, animated: false)
 ```
 
 ### JourneysRequest

--- a/docs/journey/ios/releases/5.4.7/index.md
+++ b/docs/journey/ios/releases/5.4.7/index.md
@@ -1,0 +1,13 @@
+# Journey iOS 5.4.7 Changelog
+
+<h2>🗓 18 Jul 2023</h2>
+
+#### Tasks
+- Add ridesharing offers count
+- Make ridesharing price customizable
+
+#### Fixes
+- Hide journey time for ridesharing offers
+
+#### Dependencies
+- `BookmarkSDK` > `2.3.4`


### PR DESCRIPTION
- add journey android and traffic android releases
- add around me android, bookmark android and schedule android releases
- Add changelogs for ios releases
- Add alert subscription feature
- Add missing screens
- Update index.md
- Add Traffic version 3.3.1 for iOS
- Add journey android 5.5.1
- Add journey android 5.5.2, journey ios 5.4.5
- Add journey ios 5.4.6, android 5.6.0
- finalize
- Add journey iOS 5.4.7, bookmark iOS 1.2.2, journey Android 5.6.2
- Update bookmark
