### PR TITLE
hotfix/add expert 3.3.0 2.4.0

### DIFF
--- a/docs/expert/android/changelogs.md
+++ b/docs/expert/android/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Available versions
 
+* [v3.3.0](releases/3.3.0/index.md) (_23 Aug 2023_)
 * [v3.2.2](releases/3.2.2/index.md) (_10 Jan 2023_)
 * [v3.2.1](releases/3.2.1/index.md) (_28 Sep 2022_)
 * [v3.2.0](releases/3.2.0/index.md) (_03 Aug 2022_)

--- a/docs/expert/android/index.md
+++ b/docs/expert/android/index.md
@@ -6,7 +6,7 @@ Add the following dependency in the `build.gradle` file of your application:
 
 ``` groovy
 dependencies {
-    implementation("com.kisio.navitia.sdk.data:expert:3.2.2")
+    implementation("com.kisio.navitia.sdk.data:expert:3.3.0")
 }
 ```
 

--- a/docs/expert/android/releases/3.3.0/index.md
+++ b/docs/expert/android/releases/3.3.0/index.md
@@ -1,0 +1,18 @@
+# Expert Android 2.4.0 Changelog
+
+<h2>🗓 23 Aug 2023</h2>
+
+#### Features
+- Update Graphical Isochrone API
+- Update Heat Map API
+- Update Journey API
+
+#### Fixes 
+- handle optional object in Navitia response 
+
+#### Based on Navitia
+
+https://github.com/CanalTP/navitia/releases/tag/v15.36.0
+
+#### Deployment target
+-  `iOS 14` minimun

--- a/docs/expert/ios/changelogs.md
+++ b/docs/expert/ios/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Available versions
 
+* [v2.4.0](releases/2.4.0/index.md) (_23 Aug 2023_)
 * [v2.3.4](releases/2.3.4/index.md) (_10 Jan 2023_)
 * [v2.3.3](releases/2.3.3/index.md) (_05 Jan 2023_)
 * [v2.3.2](releases/2.3.2/index.md) (_20 Oct 2022_)

--- a/docs/expert/ios/index.md
+++ b/docs/expert/ios/index.md
@@ -11,7 +11,7 @@ use_frameworks!
 source 'https://github.com/CanalTP/Podspecs.git' # Expert podspec URL
 
 target 'YOUR_PROJECT_SCHEME' do
-  pod 'ExpertSDK', '2.3.4' # Expert Pod definition
+  pod 'ExpertSDK', '2.4.0' # Expert Pod definition
 end
 ```
 

--- a/docs/expert/ios/releases/2.4.0/index.md
+++ b/docs/expert/ios/releases/2.4.0/index.md
@@ -1,0 +1,10 @@
+# Expert iOS 2.3.4 Changelog
+
+<h2>🗓 10 Jan 2022</h2>
+
+#### Tasks 
+- Change decoding process for non mandatory variables
+- Change speed type
+
+#### Based on Navitia
+<a target="_blank" href="https://github.com/CanalTP/navitia/releases/tag/v15.11.1">https://github.com/CanalTP/navitia/releases/tag/v15.11.1</a>


### PR DESCRIPTION
- add around me android 2.5.0 changelog
- add bookmark android 1.3.0 changelog
- add journey android 5.7.0 changelog
- change min android sdk version
- add schedule android 2.3.0 changelog
- add traffic android 2.3.0 changelog
- update configuration description and example
- add event tracking links for around me, bookmark, schedule and traffic
- clean arrays
- remove activity delegate sections and edit router methods for android modules
- add navigation listener sections for android modules
- Add missing ios releases
- Update versions
- Correct some words
- Add expert latest versions
