### PR TITLE
task/add journey 5.7.0 ios

### DIFF
--- a/docs/expert/android/changelogs.md
+++ b/docs/expert/android/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Available versions
 
+* [v3.4.0](releases/3.4.0/index.md) (_14 Nov 2023_)
 * [v3.3.0](releases/3.3.0/index.md) (_23 Aug 2023_)
 * [v3.2.2](releases/3.2.2/index.md) (_10 Jan 2023_)
 * [v3.2.1](releases/3.2.1/index.md) (_28 Sep 2022_)

--- a/docs/expert/android/releases/3.3.0/index.md
+++ b/docs/expert/android/releases/3.3.0/index.md
@@ -1,4 +1,4 @@
-# Expert Android 2.4.0 Changelog
+# Expert Android 3.3.0 Changelog
 
 <h2>🗓 23 Aug 2023</h2>
 
@@ -13,6 +13,3 @@
 #### Based on Navitia
 
 https://github.com/CanalTP/navitia/releases/tag/v15.36.0
-
-#### Deployment target
--  `iOS 14` minimun

--- a/docs/expert/android/releases/3.4.0/index.md
+++ b/docs/expert/android/releases/3.4.0/index.md
@@ -1,0 +1,7 @@
+# Expert Android 3.4.0 Changelog
+
+<h2>🗓 14 Nov 2023</h2>
+
+#### Based on Navitia
+
+https://github.com/hove-io/navitia/releases/tag/v15.45.0

--- a/docs/expert/ios/changelogs.md
+++ b/docs/expert/ios/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Available versions
 
+* [v2.5.0](releases/2.4.0/index.md) (_14 Nov 2023_)
 * [v2.4.0](releases/2.4.0/index.md) (_23 Aug 2023_)
 * [v2.3.4](releases/2.3.4/index.md) (_10 Jan 2023_)
 * [v2.3.3](releases/2.3.3/index.md) (_05 Jan 2023_)

--- a/docs/expert/ios/changelogs.md
+++ b/docs/expert/ios/changelogs.md
@@ -2,7 +2,8 @@
 
 ## Available versions
 
-* [v2.5.0](releases/2.4.0/index.md) (_14 Nov 2023_)
+* [v2.6.0](releases/2.6.0/index.md) (_27 Dec 2023_)
+* [v2.5.0](releases/2.5.0/index.md) (_14 Nov 2023_)
 * [v2.4.0](releases/2.4.0/index.md) (_23 Aug 2023_)
 * [v2.3.4](releases/2.3.4/index.md) (_10 Jan 2023_)
 * [v2.3.3](releases/2.3.3/index.md) (_05 Jan 2023_)

--- a/docs/expert/ios/releases/2.5.0/index.md
+++ b/docs/expert/ios/releases/2.5.0/index.md
@@ -1,0 +1,7 @@
+# Expert iOS 2.5.0 Changelog
+
+<h2>🗓 14 Nov 2023</h2>
+
+#### Based on Navitia
+
+https://github.com/hove-io/navitia/releases/tag/v15.45.0

--- a/docs/expert/ios/releases/2.6.0/index.md
+++ b/docs/expert/ios/releases/2.6.0/index.md
@@ -1,0 +1,7 @@
+# Expert iOS 2.6.0 Changelog
+
+<h2>🗓 27 Dec 2023</h2>
+
+#### Based on Navitia
+
+https://github.com/hove-io/navitia/releases/tag/v15.50.0

--- a/docs/journey/android/changelogs.md
+++ b/docs/journey/android/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Available versions
 
+* [v5.8.0](releases/5.8.0/index.md) (_14 Nov 2023_)
 * [v5.7.0](releases/5.7.0/index.md) (_23 Aug 2023_)
 * [v5.6.2](releases/5.6.2/index.md) (_18 Jul 2023_)
 * [v5.6.1](releases/5.6.1/index.md) (_30 May 2023_)

--- a/docs/journey/android/releases/5.8.0/index.md
+++ b/docs/journey/android/releases/5.8.0/index.md
@@ -1,0 +1,22 @@
+# Journey Android 5.8.0 Changelog
+
+<h2>🗓 14 Nov 2023</h2>
+
+#### Features
+- Show walking distance in journey summary
+
+#### Tasks
+- Next departures frequency are customizable
+- App id and screen id trackers added
+- Disruptions level color configuration added
+
+#### Bugs
+- Show next departures above an hour
+
+#### Dependencies
+- `com.android.tools.build:gradle` > `8.1.1`
+- `compileSdk` > `34`
+- `com.kisio.navitia.sdk.data:expert` > `3.4.0`
+- `com.kisio.navitia.sdk.engine:design` > `2.10.0`
+- `com.kisio.navitia.sdk.engine:router` > `2.1.0`
+- `com.kisio.navitia.sdk.engine:toolbox` > `1.11.0`

--- a/docs/journey/ios/changelogs.md
+++ b/docs/journey/ios/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Available versions
 
+* [v5.7.0](releases/5.7.0/index.md) (_27 Dec 2023_)
 * [v5.6.0](releases/5.6.0/index.md) (_14 Nov 2023_)
 * [v5.5.0](releases/5.5.0/index.md) (_28 Aug 2023_)
 * [v5.4.7](releases/5.4.7/index.md) (_18 Jul 2023_)

--- a/docs/journey/ios/changelogs.md
+++ b/docs/journey/ios/changelogs.md
@@ -2,6 +2,7 @@
 
 ## Available versions
 
+* [v5.6.0](releases/5.6.0/index.md) (_14 Nov 2023_)
 * [v5.5.0](releases/5.5.0/index.md) (_28 Aug 2023_)
 * [v5.4.7](releases/5.4.7/index.md) (_18 Jul 2023_)
 * [v5.4.6](releases/5.4.6/index.md) (_30 May 2023_)

--- a/docs/journey/ios/releases/5.6.0/index.md
+++ b/docs/journey/ios/releases/5.6.0/index.md
@@ -1,0 +1,28 @@
+# Journey iOS 5.6.0 Changelog
+
+<h2>🗓 14 Nov 2023</h2>
+
+#### Features
+- External view injection in journeys and roadmap screens added
+- Roadmap screen actions are now delegate dependent
+- Show walking distance in journey summary
+
+#### Tasks
+- Car path color and next departures frequency are customizable
+- Accessibility updated
+- App id and screen id trackers added
+- Disruptions level color configuration added
+
+#### Bugs
+- Fix PRM realtime icon color
+- Fix earlier/later button text
+- Fix wrong destination name in step by step screen card
+
+#### Dependencies
+- `NavitiaSDK` -> `2.5.0`
+- `ToolboxEngine` -> `1.10.0`
+- `DesignEngine` -> `2.8.0`
+- `RouterEngine` -> `1.1.0`
+
+#### Deployment target
+-  `iOS 14` minimun

--- a/docs/journey/ios/releases/5.7.0/index.md
+++ b/docs/journey/ios/releases/5.7.0/index.md
@@ -1,0 +1,17 @@
+# Journey iOS 5.7.0 Changelog
+
+<h2>🗓 27 Dec 2023</h2>
+
+#### Features
+- Add car parking highlight feature
+- Handle indoor/outdoor car parking types
+
+#### Dependencies
+- `NavitiaSDK` -> `2.6.0`
+- `ToolboxEngine` -> `1.11.0`
+- `DesignEngine` -> `2.9.0`
+- `RouterEngine` -> `1.1.1`
+- `GraphEngine` -> `1.0.5`
+
+#### Compiler
+-  Swift -> `5.9.2`


### PR DESCRIPTION
- add around me android 2.5.0 changelog
- add bookmark android 1.3.0 changelog
- add journey android 5.7.0 changelog
- change min android sdk version
- add schedule android 2.3.0 changelog
- add traffic android 2.3.0 changelog
- update configuration description and example
- add event tracking links for around me, bookmark, schedule and traffic
- clean arrays
- remove activity delegate sections and edit router methods for android modules
- add navigation listener sections for android modules
- Add missing ios releases
- Update versions
- Correct some words
- Add expert latest versions
- Add journey/expert new versions android and iOS
- Add releases
- Add expert 2.6.0, journey 5.7.0
