### PR TITLE
hotfix/aroundme android 2.13.2

### DIFF
--- a/docs/around_me/android/changelogs.md
+++ b/docs/around_me/android/changelogs.md
@@ -4,6 +4,7 @@ title: Around Me Android - Changelogs - Navitia SDK Docs
 
 # Around Me Android Changelogs
 
+* [v2.13.2](releases/2.13.2/index.md) (_26 Dec 2024_)
 * [v2.13.1](releases/2.13.1/index.md) (_24 Dec 2024_)
 * [v2.13.0](releases/2.13.0/index.md) (_02 Dec 2024_)
 * [v2.12.1](releases/2.12.1/index.md) (_19 Nov 2024_)

--- a/docs/around_me/android/index.md
+++ b/docs/around_me/android/index.md
@@ -10,7 +10,7 @@ Add the following dependencies in the `build.gradle` file of your application:
 
 ```kotlin
 dependencies {
-    implementation("com.kisio.navitia.sdk.ui:aroundme:2.13.1")
+    implementation("com.kisio.navitia.sdk.ui:aroundme:2.13.2")
 }
 ```
 

--- a/docs/around_me/android/releases/2.13.2/index.md
+++ b/docs/around_me/android/releases/2.13.2/index.md
@@ -1,0 +1,13 @@
+---
+title: AroundMe Android 2.13.2 - Changelog - Navitia SDK Docs
+---
+
+# Around Me Android 2.13.2 Changelog
+
+<h2>🗓 26 Dec 2024</h2>
+
+#### Fixes
+- Fix journey shortcut showing when journey mode is disabled
+
+#### Dependencies
+- `com.android.tools.build:gradle` > `8.7.3`


### PR DESCRIPTION
- Update changelogs.md
- Add journey version
- Remove fix doc
- Add missing task in release notes
- Fix global json
- Add iOS releases
- Add missing versions, add new versions
- Update configuration
- Changes after PR Review
- Update versions
- Add hotfix releases
- Update index.md
- Add releases
- add around me android 2.9.0
- add bookmark android 1.6.0
- add journey android 5.13.0
- add schedule android 2.7.1
- add traffic android 2.5.4
- add app theme instructions
- edit navigation listener enums
- edit communicating with for around me
- edit communicating with for bookmark
- edit communicating with for journey
- Update README.md
- test corrections
- Apply suggestions from code review
- Add release notes
- Add favorite implementations
- update bookmark doc
- update changelogs
- add around me 2.10.0
- add bookmark 1.7.0
- add journey 5.14.0
- add schedule 2.8.0
- add traffic 2.5.6
- rename title of home
- use a download file for global configuration
- rename site author
- limit table of content depth
- remove overview pages and adjust main table of contents
- remove unnecessary title in changelogs
- enhance home page
- use admonition for configuration warning
- add tabs for init function examples
- add badges for module title on the home page
- enhance getting_started page
- enhance titles level 5 in getting started
- fix some typo and clean some code snippets
- adjust main logo and main title
- add a new page for the module screen descriptions
- arrange img file tree
- hide account and crowdsourcing references
- add event tracking in around me, bookmark, schedule and traffic
- completing communicating with
- update icons
- add empty state sections
- some corrections
- update documentation
- fix indents
- Update docs/around_me/ios/index.md
- update
- Fix indent
- Fix indent
- fix indent
- Fix indent
- Fix indent
- add car_traffic_jam
- add journey 5.14.1
- add schedule 2.8.1
- add see all schedules
- use h5 for getting started
- update poi subcategory group
- add traffic_mode to schedule configuration
- remove old config key in pois
- change poi subcategory types
- add changelogs
- update doc with new traffic feature param application_periods
- update config file example
- update changelogs
- update screens
- Update docs/journey/ios/releases/5.15.0/index.md
- update changelogs
- update screens
- Update docs/journey/ios/releases/5.15.0/index.md
- add missing documentation
- finalize changes
- add 5.15.1
- Add missing ios releases
- Fix dates
- Add around me and bookmark releases
- Add traffic android release
- Fix links in table, add disruptions color
- add park availability
- Update config
- add realtime delays
- update config and getting started for bookmark mode
- fix bookmark mode documentation
- remove severity example configuration
- add new json configutation
- update getting started
- remove useless empty line
- update styling for schedule
- add new android changelogs
- update config with releases from 30-oct and 7-nov
- Apply suggestions from code review
- PR changes
- PR changes
- Apply suggestions from code review
- update changelogs
- update getting started
- Update index.md
- add android and ios changelogs
- Add update methods
- update changelogs
- Update ios changelogs
- Update ios index files
- Add bookmark hotfix release note
- clean font config
- update doc
- Add hotfix release for around me android 2.13.2
