### PR TITLE
hotfix/04 02 2025

### DIFF
--- a/docs/around_me/android/changelogs.md
+++ b/docs/around_me/android/changelogs.md
@@ -4,6 +4,7 @@ title: Around Me Android - Changelogs - Navitia SDK Docs
 
 # Around Me Android Changelogs
 
+* [v2.13.4](releases/2.13.4/index.md) (_03 Feb 2025_)
 * [v2.13.3](releases/2.13.3/index.md) (_09 Jan 2025_)
 * [v2.13.2](releases/2.13.2/index.md) (_26 Dec 2024_)
 * [v2.13.1](releases/2.13.1/index.md) (_24 Dec 2024_)

--- a/docs/around_me/android/index.md
+++ b/docs/around_me/android/index.md
@@ -10,7 +10,7 @@ Add the following dependencies in the `build.gradle` file of your application:
 
 ```kotlin
 dependencies {
-    implementation("com.kisio.navitia.sdk.ui:aroundme:2.13.3")
+    implementation("com.kisio.navitia.sdk.ui:aroundme:2.13.4")
 }
 ```
 

--- a/docs/around_me/android/releases/2.13.4/index.md
+++ b/docs/around_me/android/releases/2.13.4/index.md
@@ -1,0 +1,15 @@
+---
+title: AroundMe Android 2.13.4 - Changelog - Navitia SDK Docs
+---
+
+# Around Me Android 2.13.4 Changelog
+
+<h2>🗓 03 Feb 2025</h2>
+
+#### Fixes
+- Do not show walking sections under 3 minutes in favorites journeys.
+- Details bottomsheet not showing when selecting a POI.
+- Do not show schedule options if not enable in configuration.
+
+#### Dependencies
+- `com.kisio.navitia.sdk.engine:router` > `2.6.3`

--- a/docs/around_me/ios/changelogs.md
+++ b/docs/around_me/ios/changelogs.md
@@ -4,6 +4,7 @@ title: Around Me iOS - Changelogs - Navitia SDK Docs
 
 # Around Me iOS Changelogs
 
+* [v3.10.1](releases/3.10.1/index.md) (_04 Feb 2025_)
 * [v3.10.0](releases/3.10.0/index.md) (_02 Dec 2024_)
 * [v3.9.2](releases/3.9.2/index.md) (_19 Nov 2024_)
 * [v3.9.1](releases/3.9.1/index.md) (_07 Nov 2024_)

--- a/docs/around_me/ios/index.md
+++ b/docs/around_me/ios/index.md
@@ -13,7 +13,7 @@ source 'https://github.com/CocoaPods/Specs.git' # Default Cocoapods URL
 source 'https://github.com/hove-io/Podspecs.git' # Around Me podspec URL
 
 target 'YOUR_PROJECT_SCHEME' do
-  pod 'AroundMeSDK', '3.10.0' # Around Me Pod definition
+  pod 'AroundMeSDK', '3.10.1' # Around Me Pod definition
 end
 
 # Required for XCFramework

--- a/docs/around_me/ios/releases/3.10.1/index.md
+++ b/docs/around_me/ios/releases/3.10.1/index.md
@@ -1,0 +1,17 @@
+---
+title: AroundMe iOS 3.10.1 - Changelog - Navitia SDK Docs
+---
+
+# AroundMe iOS 3.10.1 Changelog
+
+<h2>🗓 04 Feb 2025</h2>
+
+#### Fixes
+- Fix home and work shortcuts not sending navitia id to journey
+
+#### Compiler
+-  Swift  `6.0.3`
+
+#### Dependencies
+- `DesignEngine` -> `2.18.1`
+- `RouterEngine` -> `1.5.4`

--- a/docs/bookmark/android/changelogs.md
+++ b/docs/bookmark/android/changelogs.md
@@ -4,6 +4,7 @@ title: Bookmark Android - Changelogs - Navitia SDK Docs
 
 # Bookmark Android Changelogs
 
+* [v1.9.4](releases/1.9.4/index.md) (_03 Feb 2025_)
 * [v1.9.3](releases/1.9.3/index.md) (_08 Jan 2025_)
 * [v1.9.2](releases/1.9.2/index.md) (_24 Dec 2024_)
 * [v1.9.1](releases/1.9.1/index.md) (_02 Dec 2024_)

--- a/docs/bookmark/android/index.md
+++ b/docs/bookmark/android/index.md
@@ -10,7 +10,7 @@ Add the following dependencies in the `build.gradle` file of your application:
 
 ```kotlin
 dependencies {
-    implementation("com.kisio.navitia.sdk.ui:bookmark:1.9.3")
+    implementation("com.kisio.navitia.sdk.ui:bookmark:1.9.4")
 }
 ```
 

--- a/docs/bookmark/android/index.md
+++ b/docs/bookmark/android/index.md
@@ -253,35 +253,32 @@ fun updateAddress(address: SharedData.AddressBookmark)
 :material-arrow-right: Update an existing favorite journey
 
 ```kotlin
-fun updateJourney(travelId: String, additionalInformation: String)
+fun updateJourney(journey: SharedData.JourneyBookmark)
 ```
 
 | Param | Type | Description |
 | --- | --- | --- |
-| `travelId` | `String` | Travel id of the favorite journey to update |
-| `additionalInformation` | `String` | Extra data to update |
+| `journey` | `SharedData.JourneyBookmark` | Favorite journey to update |
 
 :material-arrow-right: Update an existing favorite POI
 
 ```kotlin
-fun updatePoi(id: String, additionalInformation: String)
+fun updatePoi(poi: SharedData.PoiBookmark)
 ```
 
 | Param | Type | Description |
 | --- | --- | --- |
-| `id` | `String` | Id of the favorite POI to update |
-| `additionalInformation` | `String` | Extra data to update |
+| `poi` | `SharedData.PoiBookmark` | Favorite poi to update |
 
 :material-arrow-right: Update an existing favorite station
 
 ```kotlin
-fun updateStation(id: String, additionalInformation: String)
+fun updateStation(station: SharedData.StationBookmark)
 ```
 
 | Param | Type | Description |
 | --- | --- | --- |
-| `is` | `String` | Id of the favorite station to update |
-| `additionalInformation` | `String` | Extra data to update |
+| `station` | `SharedData.StationBookmark` | Favorite station to update |
 
 <h4>Delete</h4>
 
@@ -332,6 +329,7 @@ fun deleteStation(stopAreaId: String, lineId: String)
 
 | Name | Required | Description | Type |
 | --- |:---:| --- | :---: |
+| `databaseId` | :material-check: | Unique database id | `Long?` |
 | `id` | :material-check: | Unique address id | `String` |
 | `name` | :material-check: | Address name | `String` |
 | `houseNumber` | :material-check: | House number | `Int` |
@@ -345,6 +343,7 @@ fun deleteStation(stopAreaId: String, lineId: String)
 
 | Name | Required | Description | Type |
 | --- |:---:| --- | :---: |
+| `databaseId` | :material-check: | Unique database id | `Long?` |
 | `travelId` | :material-check: | Unique journey id | `String` |
 | `from` | :material-check: | Departure name | `String` |
 | `fromId` | :material-check: | Departure Navitia id | `String` |
@@ -386,6 +385,7 @@ fun deleteStation(stopAreaId: String, lineId: String)
 
 | Name | Required | Description | Type |
 | --- |:---:| --- | :---: |
+| `databaseId` | :material-check: | Unique database id | `Long?` |
 | `id` | :material-check: | Unique POI id | `String` |
 | `coords` | :material-check: | POI coordinates | `LatLng` |
 | `name` | :material-check: | POI name | `String` |
@@ -399,6 +399,7 @@ fun deleteStation(stopAreaId: String, lineId: String)
 
 | Name | Required | Description | Type |
 | --- |:---:| --- | :---: |
+| `databaseId` | :material-check: | Unique database id | `Long?` |
 | `stopAreaId` | :material-check: | Navitia stop area id | `String` |
 | `coords` | :material-check: | Station coordinates | `LatLng` |
 | `name` | :material-check: | Station name | `String` |

--- a/docs/bookmark/android/releases/1.9.4/index.md
+++ b/docs/bookmark/android/releases/1.9.4/index.md
@@ -1,0 +1,14 @@
+---
+title: Bookmark Android 1.9.4 - Changelog - Navitia SDK Docs
+---
+
+# Bookmark Android 1.9.4 Changelog
+
+<h2>🗓 03 Feb 2025</h2>
+
+#### Fixes
+- Fix database id issue when updating favorites
+
+#### Dependencies
+- `com.android.tools.build:gradle` > `8.7.3`
+- `com.kisio.navitia.sdk.engine:router` > `2.6.3`

--- a/docs/bookmark/ios/changelogs.md
+++ b/docs/bookmark/ios/changelogs.md
@@ -4,6 +4,7 @@ title: Bookmark iOS - Changelogs - Navitia SDK Docs
 
 # Bookmark iOS Changelogs
 
+* [v1.9.2](releases/1.9.2/index.md) (_04 Feb 2025_)
 * [v1.9.1](releases/1.9.1/index.md) (_09 Dec 2024_)
 * [v1.9.0](releases/1.9.0/index.md) (_02 Dec 2024_)
 * [v1.8.0](releases/1.8.0/index.md) (_30 Oct 2024_)

--- a/docs/bookmark/ios/index.md
+++ b/docs/bookmark/ios/index.md
@@ -360,7 +360,8 @@ func deleteFavoriteStation(id: String) -> Bool
 
 | Name | Required | Description | Type |
 | --- |:---:| --- | :---: |
-| `id` | :material-check: | Unique address id | `String` |
+| `uuid` | :material-check: | Unique database address id | `String` |
+| `navitiaId` | :material-check: | Unique navitia id | `String` |
 | `name` | :material-check: | Address name | `String` |
 | `houseNumber` | :material-check: | House number | `Int` |
 | `address` | :material-check: | Address label | `String` |
@@ -373,7 +374,8 @@ func deleteFavoriteStation(id: String) -> Bool
 
 | Name | Required | Description | Type |
 | --- |:---:| --- | :---: |
-| `id` | :material-check: | Unique journey id | `String` |
+| `uuid` | :material-check: | Unique database journey id | `String` |
+| `journeyId` | :material-check: | Unique journey id | `String` |
 | `fromName` | :material-check: | Departure name | `String` |
 | `fromId` | :material-check: | Departure Navitia id | `String` |
 | `toName` | :material-check: | Arrival name | `String` |
@@ -400,7 +402,8 @@ func deleteFavoriteStation(id: String) -> Bool
 
 | Name | Required | Description | Type |
 | --- |:---:| --- | :---: |
-| `id` | :material-check: | Unique POI id | `String` |
+| `uuid` | :material-check: | Unique database POI id | `String` |
+| `navitiaId` | :material-check: | Unique POI id | `String` |
 | `coords` | :material-check: | POI coordinates | `CLLocationCoordinate2D` |
 | `name` | :material-check: | POI name | `String` |
 | `address` | :material-check: | POI address | `String` |
@@ -413,6 +416,7 @@ func deleteFavoriteStation(id: String) -> Bool
 
 | Name | Required | Description | Type |
 | --- |:---:| --- | :---: |
+| `uuid` | :material-check: | Unique database station id | `String` |
 | `stopAreaId` | :material-check: | Navitia stop area id | `String` |
 | `coords` | :material-check: | Station coordinates | `CLLocationCoordinate2D` |
 | `name` | :material-check: | Station name | `String` |

--- a/docs/bookmark/ios/index.md
+++ b/docs/bookmark/ios/index.md
@@ -13,7 +13,7 @@ source 'https://github.com/CocoaPods/Specs.git' # Default Cocoapods URL
 source 'https://github.com/hove-io/Podspecs.git' # Bookmark podspec URL
 
 target 'YOUR_PROJECT_SCHEME' do
-  pod 'BookmarkSDK', '1.9.1' # Bookmark Pod definition
+  pod 'BookmarkSDK', '1.9.2' # Bookmark Pod definition
 end
 
 # Required for XCFramework

--- a/docs/bookmark/ios/releases/1.9.2/index.md
+++ b/docs/bookmark/ios/releases/1.9.2/index.md
@@ -1,0 +1,19 @@
+---
+title: Bookmark iOS 1.9.2 - Changelog - Navitia SDK Docs
+---
+
+# Bookmark iOS 1.9.2 Changelog
+
+<h2>🗓 04 Feb 2025</h2>
+
+#### Tasks
+- Add uuid to all bookmark models
+- Rename id to navitia id for concerned models
+- Handle update using uuid
+
+#### Compiler
+-  Swift  `6.0.3`
+
+#### Dependencies
+- `DesignEngine` -> `2.18.1`
+- `RouterEngine` -> `1.5.4`

--- a/docs/journey/android/changelogs.md
+++ b/docs/journey/android/changelogs.md
@@ -4,6 +4,7 @@ title: Journey Android - Changelogs - Navitia SDK Docs
 
 # Journey Android Changelogs
 
+* [v5.17.3](releases/5.17.3/index.md) (_03 Feb 2025_)
 * [v5.17.2](releases/5.17.2/index.md) (_08 Jan 2024_)
 * [v5.17.1](releases/5.17.1/index.md) (_24 Dec 2024_)
 * [v5.17.0](releases/5.17.0/index.md) (_02 Dec 2024_)

--- a/docs/journey/android/index.md
+++ b/docs/journey/android/index.md
@@ -10,7 +10,7 @@ Add the following dependencies in the `build.gradle` file of your application:
 
 ```kotlin
 dependencies {
-    implementation("com.kisio.navitia.sdk.ui:journey:5.17.2")
+    implementation("com.kisio.navitia.sdk.ui:journey:5.17.3")
 }
 ```
 

--- a/docs/journey/android/releases/5.17.3/index.md
+++ b/docs/journey/android/releases/5.17.3/index.md
@@ -1,0 +1,13 @@
+---
+title: Journey Android 5.17.3 - Changelog - Navitia SDK Docs
+---
+
+# Journey Android 5.17.3 Changelog
+
+<h2>🗓 03 Feb 2025</h2>
+
+#### Fixes
+- Fix address data in favorite poi
+
+#### Dependencies
+- `com.kisio.navitia.sdk.engine:router` > `2.6.3`

--- a/docs/journey/ios/changelogs.md
+++ b/docs/journey/ios/changelogs.md
@@ -4,6 +4,7 @@ title: Journey iOS - Changelogs - Navitia SDK Docs
 
 # Journey iOS Changelogs
 
+* [v5.17.3](releases/5.17.3/index.md) (_04 Feb 2025_)
 * [v5.17.2](releases/5.17.2/index.md) (_23 Jan 2025_)
 * [v5.17.1](releases/5.17.1/index.md) (_08 Jan 2025_)
 * [v5.17.0](releases/5.17.0/index.md) (_02 Dec 2024_)

--- a/docs/journey/ios/index.md
+++ b/docs/journey/ios/index.md
@@ -13,7 +13,7 @@ source 'https://github.com/CocoaPods/Specs.git' # Default Cocoapods URL
 source 'https://github.com/hove-io/Podspecs.git' # Journey podspec URL
 
 target 'YOUR_PROJECT_SCHEME' do
-  pod 'JourneySDK', '5.17.2' # Journey Pod definition
+  pod 'JourneySDK', '5.17.3' # Journey Pod definition
 end
 
 # Required for XCFramework

--- a/docs/journey/ios/releases/5.17.3/index.md
+++ b/docs/journey/ios/releases/5.17.3/index.md
@@ -1,0 +1,17 @@
+---
+title: Journey iOS 5.17.3 - Changelog - Navitia SDK Docs
+---
+
+# Journey iOS 5.17.3 Changelog
+
+<h2>🗓 04 Feb 2025</h2>
+
+#### Fixes
+- Fix car no park icon not showing for favorite journeys
+
+#### Compiler
+-  Swift  `6.0.3`
+
+#### Dependencies
+- `DesignEngine` -> `2.18.1`
+- `RouterEngine` -> `1.5.4`

--- a/docs/schedule/android/changelogs.md
+++ b/docs/schedule/android/changelogs.md
@@ -4,6 +4,7 @@ title: Schedule Android - Changelogs - Navitia SDK Docs
 
 # Schedule Android Changelogs
 
+* [v2.9.3](releases/2.9.3/index.md) (_03 Feb 2025_)
 * [v2.9.2](releases/2.9.2/index.md) (_24 Dec 2024_)
 * [v2.9.1](releases/2.9.1/index.md) (_02 Dec 2024_)
 * [v2.9.0](releases/2.9.0/index.md) (_31 Oct 2024_)

--- a/docs/schedule/android/index.md
+++ b/docs/schedule/android/index.md
@@ -10,7 +10,7 @@ Add the following dependencies in the `build.gradle` file of your application:
 
 ```kotlin
 dependencies {
-    implementation("com.kisio.navitia.sdk.ui:schedule:2.9.2")
+    implementation("com.kisio.navitia.sdk.ui:schedule:2.9.3")
 }
 ```
 

--- a/docs/schedule/android/releases/2.9.3/index.md
+++ b/docs/schedule/android/releases/2.9.3/index.md
@@ -1,0 +1,11 @@
+---
+title: Schedule Android 2.9.3 - Changelog - Navitia SDK Docs
+---
+
+# Schedule Android 2.9.3 Changelog
+
+<h2>🗓 03 Feb 2025</h2>
+
+#### Dependencies
+- `com.android.tools.build:gradle` > `8.7.3`
+- `com.kisio.navitia.sdk.engine:router` > `2.6.3`

--- a/docs/schedule/ios/changelogs.md
+++ b/docs/schedule/ios/changelogs.md
@@ -4,6 +4,7 @@ title: Schedule iOS - Changelogs - Navitia SDK Docs
 
 # Schedule iOS Changelogs
 
+* [v3.10.1](releases/3.10.1/index.md) (_04 Feb 2025_)
 * [v3.10.0](releases/3.10.0/index.md) (_02 Dec 2024_)
 * [v3.9.1](releases/3.9.1/index.md) (_07 Nov 2024_)
 * [v3.9.0](releases/3.9.0/index.md) (_30 Oct 2024_)

--- a/docs/schedule/ios/index.md
+++ b/docs/schedule/ios/index.md
@@ -13,7 +13,7 @@ source 'https://github.com/CocoaPods/Specs.git' # Default Cocoapods URL
 source 'https://github.com/hove-io/Podspecs.git' # Schedule podspec URL
 
 target 'YOUR_PROJECT_SCHEME' do
-  pod 'ScheduleSDK', '3.10.0' # Schedule Pod definition
+  pod 'ScheduleSDK', '3.10.1' # Schedule Pod definition
 end
 
 # Required for XCFramework

--- a/docs/schedule/ios/releases/3.10.1/index.md
+++ b/docs/schedule/ios/releases/3.10.1/index.md
@@ -1,0 +1,18 @@
+---
+title: Schedule iOS 3.10.1 - Changelog - Navitia SDK Docs
+---
+
+# Schedule iOS 3.10.1 Changelog
+
+<h2>🗓 04 Feb 2025</h2>
+
+#### Fixes
+- Remove Navitia call when choosing to show next departures screen from favorites list
+- Fix wrong line text color displayed
+
+#### Compiler
+-  Swift  `6.0.3`
+
+#### Dependencies
+- `DesignEngine` -> `2.18.1`
+- `RouterEngine` -> `1.5.4`

--- a/docs/traffic/android/changelogs.md
+++ b/docs/traffic/android/changelogs.md
@@ -4,6 +4,7 @@ title: Traffic Android - Changelogs - Navitia SDK Docs
 
 # Traffic Android Changelogs
 
+* [v2.7.2](releases/2.7.2/index.md) (_03 Feb 2025_)
 * [v2.7.1](releases/2.7.1/index.md) (_24 Dec 2024_)
 * [v2.7.0](releases/2.7.0/index.md) (_02 Dec 2024_)
 * [v2.6.1](releases/2.6.1/index.md) (_31 Oct 2024_)

--- a/docs/traffic/android/index.md
+++ b/docs/traffic/android/index.md
@@ -10,7 +10,7 @@ Add the following dependencies in the `build.gradle` file of your application:
 
 ```kotlin
 dependencies {
-    implementation("com.kisio.navitia.sdk.ui:traffic:2.7.1")
+    implementation("com.kisio.navitia.sdk.ui:traffic:2.7.2")
 }
 ```
 

--- a/docs/traffic/android/releases/2.7.2/index.md
+++ b/docs/traffic/android/releases/2.7.2/index.md
@@ -1,0 +1,10 @@
+---
+title: Traffic Android 2.7.2 - Changelog - Navitia SDK Docs
+---
+
+# Traffic Android 2.7.2 Changelog
+
+<h2>🗓 03 Feb 2025</h2>
+
+#### Dependencies
+- `com.kisio.navitia.sdk.engine:router` > `2.6.3`

--- a/docs/traffic/ios/changelogs.md
+++ b/docs/traffic/ios/changelogs.md
@@ -4,6 +4,7 @@ title: Traffic iOS - Changelogs - Navitia SDK Docs
 
 # Traffic iOS Changelogs
 
+* [v3.7.1](releases/3.7.1/index.md) (_04 Feb 2025_)
 * [v3.7.0](releases/3.7.0/index.md) (_02 Dec 2024_)
 * [v3.6.1](releases/3.6.1/index.md) (_30 Oct 2024_)
 * [v3.6.0](releases/3.6.0/index.md) (_17 Oct 2024_)

--- a/docs/traffic/ios/index.md
+++ b/docs/traffic/ios/index.md
@@ -13,7 +13,7 @@ source 'https://github.com/CocoaPods/Specs.git' # Default Cocoapods URL
 source 'https://github.com/hove-io/Podspecs.git' # Traffic podspec URL
 
 target 'YOUR_PROJECT_SCHEME' do
-  pod 'TrafficSDK', '3.7.0' # Traffic Pod definition
+  pod 'TrafficSDK', '3.7.1' # Traffic Pod definition
 end
 
 # Required for XCFramework

--- a/docs/traffic/ios/releases/3.7.1/index.md
+++ b/docs/traffic/ios/releases/3.7.1/index.md
@@ -1,0 +1,17 @@
+---
+title: Traffic iOS 3.7.1 - Changelog - Navitia SDK Docs
+---
+
+# Traffic iOS 3.7.1 Changelog
+
+<h2>🗓 04 Feb 2025</h2>
+
+#### Tasks
+- Update dependencies
+
+#### Compiler
+-  Swift  `6.0.3`
+
+#### Dependencies
+- `DesignEngine` -> `2.18.1`
+- `RouterEngine` -> `1.5.4`


### PR DESCRIPTION
- Update changelogs.md
- Add journey version
- Remove fix doc
- Add missing task in release notes
- Fix global json
- Add iOS releases
- Add missing versions, add new versions
- Update configuration
- Changes after PR Review
- Update versions
- Add hotfix releases
- Update index.md
- Add releases
- add around me android 2.9.0
- add bookmark android 1.6.0
- add journey android 5.13.0
- add schedule android 2.7.1
- add traffic android 2.5.4
- add app theme instructions
- edit navigation listener enums
- edit communicating with for around me
- edit communicating with for bookmark
- edit communicating with for journey
- Update README.md
- test corrections
- Apply suggestions from code review
- Add release notes
- Add favorite implementations
- update bookmark doc
- update changelogs
- add around me 2.10.0
- add bookmark 1.7.0
- add journey 5.14.0
- add schedule 2.8.0
- add traffic 2.5.6
- rename title of home
- use a download file for global configuration
- rename site author
- limit table of content depth
- remove overview pages and adjust main table of contents
- remove unnecessary title in changelogs
- enhance home page
- use admonition for configuration warning
- add tabs for init function examples
- add badges for module title on the home page
- enhance getting_started page
- enhance titles level 5 in getting started
- fix some typo and clean some code snippets
- adjust main logo and main title
- add a new page for the module screen descriptions
- arrange img file tree
- hide account and crowdsourcing references
- add event tracking in around me, bookmark, schedule and traffic
- completing communicating with
- update icons
- add empty state sections
- some corrections
- update documentation
- fix indents
- Update docs/around_me/ios/index.md
- update
- Fix indent
- Fix indent
- fix indent
- Fix indent
- Fix indent
- add car_traffic_jam
- add journey 5.14.1
- add schedule 2.8.1
- add see all schedules
- use h5 for getting started
- update poi subcategory group
- add traffic_mode to schedule configuration
- remove old config key in pois
- change poi subcategory types
- add changelogs
- update doc with new traffic feature param application_periods
- update config file example
- update changelogs
- update screens
- Update docs/journey/ios/releases/5.15.0/index.md
- update changelogs
- update screens
- Update docs/journey/ios/releases/5.15.0/index.md
- add missing documentation
- finalize changes
- add 5.15.1
- Add missing ios releases
- Fix dates
- Add around me and bookmark releases
- Add traffic android release
- Fix links in table, add disruptions color
- add park availability
- Update config
- add realtime delays
- update config and getting started for bookmark mode
- fix bookmark mode documentation
- remove severity example configuration
- add new json configutation
- update getting started
- remove useless empty line
- update styling for schedule
- add new android changelogs
- update config with releases from 30-oct and 7-nov
- Apply suggestions from code review
- PR changes
- PR changes
- Apply suggestions from code review
- update changelogs
- update getting started
- Update index.md
- add android and ios changelogs
- Add update methods
- update changelogs
- Update ios changelogs
- Update ios index files
- Add bookmark hotfix release note
- clean font config
- update doc
- Add hotfix release for around me android 2.13.2
- add changelog
- update date
- Add journey 5.17.1 release note
- Add version link
- Add journey android 5.17.2
- update doc
- Add journey ios release 5.17.2
- Update version
- Add hotfix releases
- Update bookmark ios shared models
